### PR TITLE
Target subversion plugin 1.50

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>subversion</artifactId>
-			<version>1.51-SNAPSHOT</version>
+			<version>1.50</version>
 			<type>hpi</type>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Originally, this code was written as a patch to 1.51-SNAPSHOT.  Downgrading to latest release so it can be used in production, because no patch is likely to be accepted.
